### PR TITLE
Added IMST+RPi platform

### DIFF
--- a/libloragw/inc/imst_rpi.h
+++ b/libloragw/inc/imst_rpi.h
@@ -1,0 +1,23 @@
+/*
+ * imst_rpi.h
+ *
+ *  Created on: Dec 30, 2015
+ *      Author: gonzalocasas
+ */
+
+#ifndef _IMST_RPI_H_
+#define _IMST_RPI_H_
+
+/* Human readable platform definition */
+#define DISPLAY_PLATFORM "IMST + Rpi"
+
+/* parameters for native spi */
+#define SPI_SPEED		8000000
+#define SPI_DEV_PATH	"/dev/spidev0.0"
+#define SPI_CS_CHANGE   0
+
+/* parameters for a FT2232H */
+#define VID		        0x0403
+#define PID		        0x6014
+
+#endif /* _IMST_RPI_H_ */

--- a/libloragw/inc/kerlink.h
+++ b/libloragw/inc/kerlink.h
@@ -14,6 +14,7 @@
 /* parameters for native spi */
 #define SPI_SPEED		8000000
 #define SPI_DEV_PATH	"/dev/spidev32766.0"
+#define SPI_CS_CHANGE   1
 
 /* parameters for a FT2232H */
 #define VID		        0x0403

--- a/libloragw/inc/lorank.h
+++ b/libloragw/inc/lorank.h
@@ -14,6 +14,7 @@
 /* parameters for native spi */
 #define SPI_SPEED		8000000
 #define SPI_DEV_PATH	"/dev/spidev1.0"
+#define SPI_CS_CHANGE   1
 
 /* parameters for a FT2232H */
 #define VID		        0x0403

--- a/libloragw/library.cfg
+++ b/libloragw/library.cfg
@@ -17,6 +17,7 @@ CFG_SPI= native
 # Accepted values:
 #  kerlink     This is the default from Semtech and works for the Kerlink
 #  lorank      This is for the Lorank, and probably for any gateway based on the IMST concentrator.
+#  imst_rpi    This is for the IMST concentrators with a Raspberry Pi host.
 
 PLATFORM= kerlink
 

--- a/libloragw/src/loragw_spi.native.c
+++ b/libloragw/src/loragw_spi.native.c
@@ -182,7 +182,7 @@ int lgw_spi_w(void *spi_target, uint8_t address, uint8_t data) {
 	k.tx_buf = (unsigned long) out_buf;
 	k.len = ARRAY_SIZE(out_buf);
 	k.speed_hz = SPI_SPEED;
-	k.cs_change = 1;
+	k.cs_change = SPI_CS_CHANGE;
 	k.bits_per_word = 8;
 	a = ioctl(spi_device, SPI_IOC_MESSAGE(1), &k);
 
@@ -224,7 +224,7 @@ int lgw_spi_r(void *spi_target, uint8_t address, uint8_t *data) {
 	k.tx_buf = (unsigned long) out_buf;
 	k.rx_buf = (unsigned long) in_buf;
 	k.len = ARRAY_SIZE(out_buf);
-	k.cs_change = 1;
+	k.cs_change = SPI_CS_CHANGE;
 	a = ioctl(spi_device, SPI_IOC_MESSAGE(1), &k);
 
 	/* determine return code */
@@ -271,7 +271,7 @@ int lgw_spi_wb(void *spi_target, uint8_t address, uint8_t *data, uint16_t size) 
 	k[0].tx_buf = (unsigned long) &command;
 	k[0].len = 1;
 	k[0].cs_change = 0;
-	k[1].cs_change = 1;
+	k[1].cs_change = SPI_CS_CHANGE;
 	for (i=0; size_to_do > 0; ++i) {
 		chunk_size = (size_to_do < LGW_BURST_CHUNK) ? size_to_do : LGW_BURST_CHUNK;
 		offset = i * LGW_BURST_CHUNK;
@@ -325,7 +325,7 @@ int lgw_spi_rb(void *spi_target, uint8_t address, uint8_t *data, uint16_t size) 
 	k[0].tx_buf = (unsigned long) &command;
 	k[0].len = 1;
 	k[0].cs_change = 0;
-	k[1].cs_change = 1;
+	k[1].cs_change = SPI_CS_CHANGE;
 	for (i=0; size_to_do > 0; ++i) {
 		chunk_size = (size_to_do < LGW_BURST_CHUNK) ? size_to_do : LGW_BURST_CHUNK;
 		offset = i * LGW_BURST_CHUNK;


### PR DESCRIPTION
We found some small differences between the configuration required for `lorank` platform (IMST + BB) and the one required to run an IMST concentrator (SPI version) with a Raspberry Pi host, so, we added a new platform to cover those cases.
