### PR TITLE
Added support for half duplex & mtk platform

### DIFF
--- a/libloragw/Makefile
+++ b/libloragw/Makefile
@@ -74,6 +74,7 @@ inc/config.h: ../VERSION library.cfg
 	@echo "	#define DEBUG_HAL	$(DEBUG_HAL)" >> $@
 	@echo "	#define DEBUG_GPS	$(DEBUG_GPS)" >> $@
 	@echo "	#define DEBUG_GPIO	$(DEBUG_GPIO)" >> $@
+	@echo "	#define CFG_SPI_HALF_DUPLEX	$(CFG_SPI_HALF_DUPLEX)" >> $@
   # Platform selection
 	@echo "	#include \"$(PLATFORM).h\"" >> $@
   # end of file

--- a/libloragw/inc/mtk.h
+++ b/libloragw/inc/mtk.h
@@ -1,0 +1,19 @@
+/*
+ * mtk.h
+ *
+ *  Created on: Sep 25, 2017
+ *      Author: benjaminmarty
+ */
+
+#ifndef _MTK_H_
+#define _MTK_H_
+
+/* Human readable platform definition */
+#define DISPLAY_PLATFORM "MTK"
+
+/* parameters for native spi */
+#define SPI_SPEED		8000000
+#define SPI_DEV_PATH	"/dev/spidev32766.1"
+#define SPI_CS_CHANGE   0
+
+#endif /* _MTK_H_ */

--- a/libloragw/library.cfg
+++ b/libloragw/library.cfg
@@ -12,6 +12,11 @@
 
 CFG_SPI= native
 
+### SPI native half-duplex flag ###
+# Set the flag to 1 to enable the half-duplex mode, needed for HW which can't
+# make full-duplex spi calls
+CFG_SPI_HALF_DUPLEX= 0
+
 
 ### Specify which platform you are on. 
 # Accepted values:
@@ -19,6 +24,7 @@ CFG_SPI= native
 #  lorank      This is for the Lorank (BeagleBone + IMST concentrator).
 #  imst_rpi    This is for the IMST concentrators with a Raspberry Pi host.
 #  linklabs_blowfish_rpi This is for the LinkLabs concentrators with a Raspberry Pi host.
+#  mtk         This is for MTK devices with device /dev/spidev32766.1
 
 PLATFORM= kerlink
 


### PR DESCRIPTION
Devices like the MT7688a can't handle full duplex SPI transfers. Thus I made a modification to "enable" half-duplex transfers and added a device header file for the device name of the SPI Device on those devices.